### PR TITLE
Refactor: simplify transformer API and support metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,17 +23,6 @@ view = model_view(model)
 which gives  
 ![Screenshot of result of `model_view`](images/model_view.png)
 
-There is also a `model_view_for` function to generate the view from the model class:
-```python
-from traitlet_widgets import model_view_for
-
-model = Model()
-view = model_view_for(Model)
-view.value = model
-```
-
-At present, this does not return the view class, and as such is of limited use.
-
 ## UI Customisation
 The UI can be customised through the use of `TraitType.tag()` or a custom transformer function.
 
@@ -63,11 +52,11 @@ class Model(HasTraits):
     name = Unicode()
     age = Integer()
 
-def transform_trait(ctx, model, name, trait, widget):
-    if name == "name":
+def transform_trait(model, trait, widget, ctx):
+    if ctx.name == "name":
         widget.description = "Model name"
 
-model_view(Model(), transformer=transform_trait)
+model_view(Model(), transform_trait=transform_trait)
 ```
 
 ![Screenshot of result of `model_view`](images/model_view_tag.png)
@@ -87,17 +76,23 @@ model_view(Model())
 ![Screenshot of result of `model_view`](images/model_view_slider.png)
 
 ```python
-from traitlet_widgets import create_trait_view, model_view
 import ipywidgets as widgets
 
-def transform_trait(ctx, model, name, trait, widget):
-    if name == "age":
-        new_widget = create_trait_view(ctx, trait, variant=widgets.BoundedIntText)
-        return new_widget
+def transform_trait(model, trait, widget, ctx):
+    if ctx.name == "age":
+        # Create a bounded int text instead of a slider
+        return ctx.create_trait_view(
+            trait, {"variant": widgets.BoundedIntText, "description": ctx.display_name}
+        )
 
-model_view(Model(), transformer=transform_trait)
+
+model_view(Model(), transform_trait=transform_trait)
 ```
 
 ![Screenshot of result of `model_view`](images/model_view_bounded.png)
 
 This approach may be preferred if there is a desire to remove UI descriptions from the model.
+
+### Further Customisation
+Through the transformer mechanism, the `ViewFactoryContext` context object can be used to create particular widget variants and customised widgets. Alternatively, you can inject your own widgets here simply by returning them.
+All widgets are linked to the underlying model through the `value` trait. The widget must also provide `disabled` and `description` traits. 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ from traitlet_widgets import model_view_for
 
 model = Model()
 view = model_view_for(Model)
-view.model = model
+view.value = model
 ```
 
 At present, this does not return the view class, and as such is of limited use.

--- a/traitlet_widgets/__init__.py
+++ b/traitlet_widgets/__init__.py
@@ -2,7 +2,7 @@ from .filters import *
 from .view import model_view, model_view_for
 from .view_factories import (
     create_trait_view,
-    create_has_traits_widgets,
+    create_widgets_for_model_cls,
     register_trait_view_variant_factory,
     unregister_trait_view_variant_factory,
     trait_view_variants,

--- a/traitlet_widgets/__init__.py
+++ b/traitlet_widgets/__init__.py
@@ -1,8 +1,6 @@
 from .filters import *
-from .view import model_view, model_view_for
+from .view import model_view
 from .view_factories import (
-    create_trait_view,
-    create_widgets_for_model_cls,
     register_trait_view_variant_factory,
     unregister_trait_view_variant_factory,
     trait_view_variants,

--- a/traitlet_widgets/__init__.py
+++ b/traitlet_widgets/__init__.py
@@ -2,6 +2,7 @@ from .filters import *
 from .view import model_view, model_view_for
 from .view_factories import (
     create_trait_view,
+    create_has_traits_widgets,
     register_trait_view_variant_factory,
     unregister_trait_view_variant_factory,
     trait_view_variants,

--- a/traitlet_widgets/filters.py
+++ b/traitlet_widgets/filters.py
@@ -2,7 +2,7 @@ from typing import Tuple
 
 import traitlets
 
-from .view_factories import CanFollowTraitType
+from .view_factories import FilterType
 
 
 def logical_and(left, right):
@@ -43,30 +43,38 @@ boolean_expression = BooleanExpression
 
 
 @boolean_expression
-def is_public_trait(model: traitlets.HasTraits, path: Tuple[str, ...]) -> bool:
+def is_public_trait(
+    model: traitlets.HasTraits, path: Tuple[str, ...], trait: traitlets.TraitType
+) -> bool:
     return not path[-1].startswith("_")
 
 
 @boolean_expression
-def is_own_trait(model: traitlets.HasTraits, path: Tuple[str, ...]) -> bool:
+def is_own_trait(
+    model: traitlets.HasTraits, path: Tuple[str, ...], trait: traitlets.TraitType
+) -> bool:
     return path[-1] in model.class_own_traits()
 
 
-def is_whitelisted(*paths: Tuple[str]) -> CanFollowTraitType:
+def is_whitelisted(*paths: Tuple[str]) -> FilterType:
     whitelist = set(paths)
 
     @boolean_expression
-    def wrapper(model: traitlets.HasTraits, path: Tuple[str, ...]) -> bool:
+    def wrapper(
+        model: traitlets.HasTraits, path: Tuple[str, ...], trait: traitlets.TraitType
+    ) -> bool:
         return path in whitelist
 
     return wrapper
 
 
-def is_not_blacklisted(*paths: Tuple[str]) -> CanFollowTraitType:
+def is_not_blacklisted(*paths: Tuple[str]) -> FilterType:
     blacklist = set(paths)
 
     @boolean_expression
-    def wrapper(model: traitlets.HasTraits, path: Tuple[str, ...]) -> bool:
+    def wrapper(
+        model: traitlets.HasTraits, path: Tuple[str, ...], trait: traitlets.TraitType
+    ) -> bool:
         return path not in blacklist
 
     return wrapper

--- a/traitlet_widgets/view.py
+++ b/traitlet_widgets/view.py
@@ -4,69 +4,36 @@ from typing import Type, Dict, Any, Tuple
 import traitlets
 
 from .view_factories import (
-    create_widgets_for_model_cls,
-    has_traits_view_factory,
-    CanFollowTraitType,
-    ViewContext,
+    FilterType,
+    ViewFactory,
     TransformerType,
 )
 from .widgets import ModelViewWidget
 
-logger = getLogger(__name__)
-
-
-def default_can_follow_trait(model: traitlets.HasTraits, path: Tuple[str, ...]) -> bool:
-    return True
-
-
-def model_view_for(
-    model_cls: Type[traitlets.HasTraits],
-    transformer: TransformerType = None,
-    namespace: Dict[str, Any] = None,
-    logger: Logger = logger,
-    can_follow_trait: CanFollowTraitType = default_can_follow_trait,
-    **kwargs: Dict[str, Any]
-) -> "ModelViewWidget":
-    """Generate a view for a model
-
-    :param model_cls: observable (`.observe`) model class
-    :param transformer: function to visit found members
-    :param namespace: namespace for lookups
-    :param logger: logger to use
-    :param can_follow_trait: condition function to determine whether to follow traits by path
-    :return:
-    """
-
-    ctx = ViewContext(
-        transformer=transformer,
-        namespace=namespace or {},
-        logger=logger,
-        visited=set(),
-        path=(),
-        can_follow_trait=can_follow_trait,
-    )
-    model_widget_class = ModelViewWidget.specialise_for_cls(model_cls)
-    return model_widget_class(ctx, **kwargs)
+default_logger = getLogger(__name__)
 
 
 def model_view(
     model: traitlets.HasTraits,
-    transformer: TransformerType = None,
+    transform_trait: TransformerType = None,
+    filter_trait: FilterType = None,
     namespace: Dict[str, Any] = None,
-    logger: Logger = logger,
-    can_follow_trait: CanFollowTraitType = default_can_follow_trait,
+    logger: Logger = default_logger,
     **kwargs: Dict[str, Any]
 ) -> "ModelViewWidget":
+    factory = ViewFactory(
+        filter_trait=filter_trait,
+        transform_trait=transform_trait,
+        namespace=namespace,
+        logger=logger,
+    )
     """Generate a view for a model
 
     :param model: observable (`.observe`) model
-    :param transformer: function to visit found members
+    :param transform_trait: function to visit found members
     :param namespace: namespace for lookups
     :param logger: logger to use
-    :param can_follow_trait: condition function to determine whether to follow traits by path
+    :param filter_trait: condition function to determine whether to follow traits by path
     :return:
     """
-    view = model_view_for(
-        type(model), transformer, namespace, logger, can_follow_trait, value=model, **kwargs
-    )
-    return view
+    return factory.create_root_view(model, metadata=kwargs)

--- a/traitlet_widgets/view.py
+++ b/traitlet_widgets/view.py
@@ -4,12 +4,13 @@ from typing import Type, Dict, Any, Tuple
 import traitlets
 
 from .view_factories import (
+    create_widgets_for_model_cls,
     has_traits_view_factory,
     CanFollowTraitType,
     ViewContext,
     TransformerType,
 )
-from .widgets import HasTraitsViewWidget
+from .widgets import ModelViewWidget
 
 logger = getLogger(__name__)
 
@@ -24,7 +25,8 @@ def model_view_for(
     namespace: Dict[str, Any] = None,
     logger: Logger = logger,
     can_follow_trait: CanFollowTraitType = default_can_follow_trait,
-) -> "HasTraitsViewWidget":
+    **kwargs: Dict[str, Any]
+) -> "ModelViewWidget":
     """Generate a view for a model
 
     :param model_cls: observable (`.observe`) model class
@@ -43,7 +45,8 @@ def model_view_for(
         path=(),
         can_follow_trait=can_follow_trait,
     )
-    return has_traits_view_factory(model_cls, ctx)
+    model_widget_class = ModelViewWidget.specialise_for_cls(model_cls)
+    return model_widget_class(ctx, **kwargs)
 
 
 def model_view(
@@ -52,7 +55,8 @@ def model_view(
     namespace: Dict[str, Any] = None,
     logger: Logger = logger,
     can_follow_trait: CanFollowTraitType = default_can_follow_trait,
-) -> "HasTraitsViewWidget":
+    **kwargs: Dict[str, Any]
+) -> "ModelViewWidget":
     """Generate a view for a model
 
     :param model: observable (`.observe`) model
@@ -62,6 +66,7 @@ def model_view(
     :param can_follow_trait: condition function to determine whether to follow traits by path
     :return:
     """
-    view = model_view_for(type(model), transformer, namespace, logger, can_follow_trait, )
-    view.model = model
+    view = model_view_for(
+        type(model), transformer, namespace, logger, can_follow_trait, value=model, **kwargs
+    )
     return view

--- a/traitlet_widgets/widgets.py
+++ b/traitlet_widgets/widgets.py
@@ -1,4 +1,4 @@
-from typing import Dict, Type, Union
+from typing import Type, Union
 
 import ipywidgets as widgets
 import traitlets
@@ -7,25 +7,36 @@ import traitlets
 class ModelViewWidget(widgets.HBox):
     """Widget to render a view over a a model"""
 
-    value = traitlets.Instance(object)
     ctx = traitlets.Instance(object)
     description = traitlets.Unicode()
+    disabled = traitlets.Bool(False)
+    value = traitlets.Instance(object)
 
     def __init__(self, ctx, **kwargs):
-        self.description_widget = widgets.Label()
-        widgets.link((self.description_widget, 'value'), (self, 'description'))
+        self.description_widget = widgets.Label(value=kwargs.get("description", ""))
+        widgets.link((self.description_widget, "value"), (self, "description"))
 
         self._links = []
         self._logger = ctx.logger
 
-        from .view_factories import create_widgets_for_model_cls
-        model_widgets = create_widgets_for_model_cls(type(self).value.klass, ctx)
+        model_widgets = ctx.create_widgets_for_model_cls(
+            ctx.resolve(type(self).value.klass)
+        )
 
-        if "value" in model_widgets:
-            raise ValueError("Trait name 'value' not permitted in model")
+        shared_trait_names = self.class_traits().keys() & model_widgets.keys()
+        if shared_trait_names:
+            raise ValueError(
+                f"Traits {shared_trait_names} clash with builtin widget trait names"
+            )
 
         self.widgets = model_widgets
-        super().__init__(children=[self.description_widget, widgets.VBox(list(model_widgets.values()))], **kwargs)
+        super().__init__(
+            children=[
+                self.description_widget,
+                widgets.VBox(list(model_widgets.values())),
+            ],
+            **kwargs,
+        )
 
     @classmethod
     def specialise_for_cls(
@@ -49,7 +60,7 @@ class ModelViewWidget(widgets.HBox):
         for n, w in self.widgets.items():
             try:
                 self._links.append(widgets.link((model, n), (w, "value")))
+                self._links.append(widgets.link((self, "disabled"), (w, "disabled")))
             except:
                 if self._logger is not None:
                     self._logger.exception(f"Error in linking widget {n}")
-

--- a/traitlet_widgets/widgets.py
+++ b/traitlet_widgets/widgets.py
@@ -4,40 +4,52 @@ import ipywidgets as widgets
 import traitlets
 
 
-class HasTraitsViewWidget(widgets.VBox):
+class ModelViewWidget(widgets.HBox):
     """Widget to render a view over a a model"""
 
-    model = traitlets.Instance(object)
+    value = traitlets.Instance(object)
+    ctx = traitlets.Instance(object)
+    description = traitlets.Unicode()
 
-    def __init__(self, widgets_: Dict[str, widgets.Widget], logger, **kwargs):
-        self.links = []
-        self.widgets = widgets_
-        self.logger = logger
-        super().__init__(tuple(widgets_.values()), **kwargs)
+    def __init__(self, ctx, **kwargs):
+        self.description_widget = widgets.Label()
+        widgets.link((self.description_widget, 'value'), (self, 'description'))
+
+        self._links = []
+        self._logger = ctx.logger
+
+        from .view_factories import create_widgets_for_model_cls
+        model_widgets = create_widgets_for_model_cls(type(self).value.klass, ctx)
+
+        if "value" in model_widgets:
+            raise ValueError("Trait name 'value' not permitted in model")
+
+        self.widgets = model_widgets
+        super().__init__(children=[self.description_widget, widgets.VBox(list(model_widgets.values()))], **kwargs)
 
     @classmethod
     def specialise_for_cls(
         cls, klass: Union[Type[traitlets.HasTraits], str]
-    ) -> Type["HasTraitsViewWidget"]:
+    ) -> Type["ModelViewWidget"]:
         """Create a specialised _ModelWidget for a given class
 
         :param klass: `HasTraits` subclass or class name
         :return:
         """
         klass_name = getattr(klass, "__name__", klass)
-        return type(f"{klass_name}View", (cls,), {"model": traitlets.Instance(klass)})
+        return type(f"{klass_name}View", (cls,), {"value": traitlets.Instance(klass)})
 
-    @traitlets.observe("model")
-    def _value_changed(self, change):
-        for link in self.links:
+    @traitlets.observe("value")
+    def _model_changed(self, change):
+        for link in self._links:
             link.unlink()
+        self._links.clear()
 
         model = change["new"]
-        self.links.clear()
-
         for n, w in self.widgets.items():
             try:
-                widgets.link((model, n), (w, "value"))
+                self._links.append(widgets.link((model, n), (w, "value")))
             except:
-                if self.logger is not None:
-                    self.logger.exception(f"Error in linking widget {n}")
+                if self._logger is not None:
+                    self._logger.exception(f"Error in linking widget {n}")
+


### PR DESCRIPTION
This PR explicitly adds support for meta data besides tags, and simplifies the user API for use in transformers.